### PR TITLE
Add basic WordPress .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# WordPress uploads
+wp-content/uploads/
+wp-content/cache/
+wp-content/ai1wm-backups/
+# All-in-One WP Migration backups
+*.wpress
+
+# System files
+.DS_Store
+Thumbs.db
+
+# Logs
+debug.log
+*.log
+
+# Environment files
+.env
+.env.*
+
+# Node dependencies
+node_modules/
+
+# Build artifacts
+build/
+dist/
+
+# Dependency directories
+vendor/
+


### PR DESCRIPTION
## Summary
- add `.gitignore` for common WordPress directories and general temp files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68687171a6bc832e896912ba5c5dda7d