### PR TITLE
Update .gitignore for WP backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # WordPress uploads
-wp-content/uploads/
-wp-content/cache/
-wp-content/ai1wm-backups/
+**/wp-content/uploads/
+**/wp-content/cache/
+**/wp-content/ai1wm-backups/
 # All-in-One WP Migration backups
 *.wpress
 


### PR DESCRIPTION
## Summary
- update `.gitignore` rules so WordPress uploads, caches, and backups are ignored anywhere in the project

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868893ae448832eb7ef68c25b5fceba