### PR TITLE
Update README with backup removal instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ git add .gitattributes
 
 GitHub blocks files larger than 100 MB unless they are handled with LFS.
 
+## Removing a committed backup
+
+If a `.wpress` archive or other backup was accidentally committed, untrack it
+while keeping the local copy:
+
+```bash
+git rm --cached path/to/file.wpress
+git commit -m "Remove large backup"
+```
+
+After removing the file from the repository, add the pattern to `.gitignore` or
+track it with Git LFS to prevent future commits.
+
 ## License
 
 This project is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- document how to untrack a mistaken `.wpress` backup and commit its removal
- mention adding the pattern to `.gitignore` or using Git LFS afterward

## Testing
- `ls -R | head`

------
https://chatgpt.com/codex/tasks/task_e_686889424660832e8a960a9b8d15f0a1