### PR TITLE
Avoid 503 response during security lockout

### DIFF
--- a/wp-content/plugins/hide-my-wp/models/compatibility/AioSecurity.php
+++ b/wp-content/plugins/hide-my-wp/models/compatibility/AioSecurity.php
@@ -29,7 +29,8 @@ class HMWP_Models_Compatibility_AioSecurity extends HMWP_Models_Compatibility_Ab
 		if (defined('AIO_WP_SECURITY_PATH') ) {
 			if (empty($content) ) {
 				nocache_headers();
-				header("HTTP/1.0 503 Service Unavailable");
+                               // Send 403 instead of 503 to avoid service unavailable errors
+                               header('HTTP/1.1 403 Forbidden');
 				remove_action('wp_head', 'head_addons', 7);
 
 				ob_start();


### PR DESCRIPTION
## Summary
- prevent Hide My WP's AIO Security compatibility from sending 503 errors by returning 403 instead

## Testing
- `php -l wp-content/plugins/hide-my-wp/models/compatibility/AioSecurity.php`


------
https://chatgpt.com/codex/tasks/task_e_68a65a5ad418832ea46664a2a671be8c