### PR TITLE
Add basic hero and featured listings homepage

### DIFF
--- a/wp-content/themes/kava/front-page.php
+++ b/wp-content/themes/kava/front-page.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Front page template.
+ *
+ * Provides a simple hero section with search form and
+ * a featured listings grid to improve the default homepage.
+ *
+ * @package Kava
+ */
+
+get_header();
+?>
+
+<section class="hero">
+    <div class="container">
+        <h1><?php bloginfo( 'name' ); ?></h1>
+        <p><?php bloginfo( 'description' ); ?></p>
+        <?php get_search_form(); ?>
+    </div>
+</section>
+
+<section class="featured-properties">
+    <div class="container">
+        <h2><?php _e( 'Featured Listings', 'kava' ); ?></h2>
+        <?php
+        $featured = new WP_Query( array(
+            'post_type'      => 'post',
+            'posts_per_page' => 3,
+        ) );
+
+        if ( $featured->have_posts() ) :
+            echo '<div class="properties">';
+            while ( $featured->have_posts() ) : $featured->the_post(); ?>
+                <article <?php post_class(); ?>>
+                    <a href="<?php the_permalink(); ?>">
+                        <?php if ( has_post_thumbnail() ) {
+                            the_post_thumbnail( 'medium' );
+                        } ?>
+                        <h3><?php the_title(); ?></h3>
+                    </a>
+                </article>
+            <?php endwhile;
+            echo '</div>';
+            wp_reset_postdata();
+        else :
+            _e( 'No listings found.', 'kava' );
+        endif;
+        ?>
+    </div>
+</section>
+
+<?php
+get_footer();

--- a/wp-content/themes/kava/style.css
+++ b/wp-content/themes/kava/style.css
@@ -1655,3 +1655,35 @@ html {
 		align-self: flex-end;
 	}
 }
+
+/* Custom front page styles */
+.hero {
+    padding: 80px 0;
+    text-align: center;
+    background: #f5f5f5;
+}
+.hero h1 {
+    font-size: 3rem;
+    margin-bottom: 0.5rem;
+}
+.hero p {
+    margin-bottom: 1.5rem;
+}
+.hero .search-form {
+    max-width: 500px;
+    margin: 0 auto;
+}
+
+.featured-properties {
+    padding: 40px 0;
+}
+.featured-properties .properties {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    justify-content: center;
+}
+.featured-properties article {
+    width: 280px;
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- Introduce `front-page.php` with hero section, search bar, and featured listing grid
- Style the hero and featured listing sections for a more polished landing page

## Testing
- `php -l wp-content/themes/kava/front-page.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b126ae1f34832eb9840027b49d2e3f