### PR TITLE
Add CTA button to Kava theme homepage

### DIFF
--- a/wp-content/themes/kava/front-page.php
+++ b/wp-content/themes/kava/front-page.php
@@ -16,6 +16,9 @@ get_header();
         <h1><?php bloginfo( 'name' ); ?></h1>
         <p><?php bloginfo( 'description' ); ?></p>
         <?php get_search_form(); ?>
+        <a class="cta-button" href="<?php echo esc_url( get_post_type_archive_link( 'post' ) ); ?>">
+            <?php _e( 'Browse All Posts', 'kava' ); ?>
+        </a>
     </div>
 </section>
 

--- a/wp-content/themes/kava/style.css
+++ b/wp-content/themes/kava/style.css
@@ -1673,6 +1673,18 @@ html {
     max-width: 500px;
     margin: 0 auto;
 }
+.hero .cta-button {
+    display: inline-block;
+    margin-top: 1rem;
+    padding: 0.75rem 1.5rem;
+    background: #333;
+    color: #fff;
+    text-decoration: none;
+    border-radius: 4px;
+}
+.hero .cta-button:hover {
+    background: #555;
+}
 
 .featured-properties {
     padding: 40px 0;


### PR DESCRIPTION
## Summary
- add call-to-action button linking to posts archive on the Kava theme front page
- style the new button for consistent theme appearance

## Testing
- `php -l wp-content/themes/kava/front-page.php`

------
https://chatgpt.com/codex/tasks/task_e_68bcf61ec838832e9d28eccd6b1d9e82