### PR TITLE
fix: properly quote DB password length check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,7 +144,13 @@ jobs:
           DB_NAME=$(extract DB_NAME)
           DB_USER=$(extract DB_USER)
           DB_HOST=$(extract DB_HOST)
-          PW_LEN=$(ssh -p "$HOSTINGER_SSH_PORT" "$HOSTINGER_SSH_USER@$HOSTINGER_SSH_HOST" "grep -E \"define\\( *'DB_PASSWORD'\\" '$CFG_PATH' | sed -E \"s/.*'DB_PASSWORD' *, *'([^']*)'.*/\\1/\" | awk '{print length($0)}'" 2>/dev/null || echo 0)
+          PW_LEN=$(
+            ssh -p "$HOSTINGER_SSH_PORT" "$HOSTINGER_SSH_USER@$HOSTINGER_SSH_HOST" \
+              "grep -E \"define\( *'DB_PASSWORD'\" '$CFG_PATH' | \
+               sed -E \"s/.*'DB_PASSWORD' *, *'([^']*)'.*/\1/\" | \
+               awk '{print length(\$0)}'" \
+            2>/dev/null || echo 0
+          )
           echo "[db-preflight] DB_NAME=$DB_NAME DB_USER=$DB_USER DB_HOST=$DB_HOST DB_PASSWORD_LEN=$PW_LEN"
           if [ -z "$DB_HOST" ] || [ -z "$DB_NAME" ] || [ -z "$DB_USER" ]; then
             echo "[db-preflight][warn] Missing DB constants; continuing"


### PR DESCRIPTION
## Summary
- properly quote remote command computing DB password length in deploy workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd00cebef4832e9a07f15fc39ad7fd