### PR TITLE
ci: skip remote snapshot without secrets

### DIFF
--- a/.github/workflows/remote-snapshot.yml
+++ b/.github/workflows/remote-snapshot.yml
@@ -16,6 +16,8 @@ permissions:
 
 jobs:
   snapshot:
+    # Skip job entirely if required secrets are missing
+    if: ${{ secrets.HOSTINGER_SSH_HOST != '' && secrets.HOSTINGER_SSH_USER != '' && secrets.HOSTINGER_SSH_PORT != '' && secrets.HOSTINGER_PATH != '' && secrets.HOSTINGER_SSH_KEY != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## Summary
- avoid failing remote snapshot workflow when Hostinger secrets are missing by skipping the job

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bedd81f3e8832e8248a31ef4a97c73