### PR TITLE
Fix homepage template and configure debug logging

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -97,7 +97,8 @@ if ( getenv( 'WP_SITEURL' ) ) {
 if ( ! defined( 'WP_DEBUG' ) ) {
     define( 'WP_DEBUG', true );
 }
-define( 'WP_DEBUG_LOG', true );
+// Log debug messages to a file in wp-content for easier troubleshooting.
+define( 'WP_DEBUG_LOG', __DIR__ . '/wp-content/debug.log' );
 define( 'WP_DEBUG_DISPLAY', false );
 
 /* That's all, stop editing! Happy publishing. */

--- a/wp-content/themes/kava/front-page.php
+++ b/wp-content/themes/kava/front-page.php
@@ -54,3 +54,4 @@ get_header();
 
 <?php
 get_footer();
+?>


### PR DESCRIPTION
## Summary
- Ensure front-page template closes PHP properly
- Route WP debug log to a deterministic file for easier troubleshooting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bee9012afc832eb196d386aead02f7