### PR TITLE
Fix secrets conditional in remote snapshot workflow

### DIFF
--- a/.github/workflows/remote-snapshot.yml
+++ b/.github/workflows/remote-snapshot.yml
@@ -14,22 +14,25 @@ on:
 permissions:
   contents: read
 
+env:
+  HOSTINGER_SSH_HOST: ${{ secrets.HOSTINGER_SSH_HOST }}
+  HOSTINGER_SSH_USER: ${{ secrets.HOSTINGER_SSH_USER }}
+  HOSTINGER_SSH_PORT: ${{ secrets.HOSTINGER_SSH_PORT }}
+  HOSTINGER_PATH: ${{ secrets.HOSTINGER_PATH }}
+  HOSTINGER_SSH_KEY: ${{ secrets.HOSTINGER_SSH_KEY }}
+  # Optional baseline & thresholds for drift alerting
+  BASELINE_WP_CONFIG_LINES: ${{ secrets.BASELINE_WP_CONFIG_LINES }}
+  BASELINE_WP_CONFIG_MD5: ${{ secrets.BASELINE_WP_CONFIG_MD5 }}
+  DRIFT_PERMISSIVE: ${{ secrets.DRIFT_PERMISSIVE }}
+  MIN_WP_CONFIG_LINES: ${{ vars.MIN_WP_CONFIG_LINES }}
+
 jobs:
   snapshot:
     # Skip job entirely if required secrets are missing
-    if: ${{ secrets.HOSTINGER_SSH_HOST != '' && secrets.HOSTINGER_SSH_USER != '' && secrets.HOSTINGER_SSH_PORT != '' && secrets.HOSTINGER_PATH != '' && secrets.HOSTINGER_SSH_KEY != '' }}
+    if: ${{ env.HOSTINGER_SSH_HOST != '' && env.HOSTINGER_SSH_USER != '' && env.HOSTINGER_SSH_PORT != '' && env.HOSTINGER_PATH != '' && env.HOSTINGER_SSH_KEY != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      HOSTINGER_SSH_HOST: ${{ secrets.HOSTINGER_SSH_HOST }}
-      HOSTINGER_SSH_USER: ${{ secrets.HOSTINGER_SSH_USER }}
-      HOSTINGER_SSH_PORT: ${{ secrets.HOSTINGER_SSH_PORT }}
-      HOSTINGER_PATH: ${{ secrets.HOSTINGER_PATH }}
-      # Optional baseline & thresholds for drift alerting
-      BASELINE_WP_CONFIG_LINES: ${{ secrets.BASELINE_WP_CONFIG_LINES }}
-      BASELINE_WP_CONFIG_MD5: ${{ secrets.BASELINE_WP_CONFIG_MD5 }}
-      MIN_WP_CONFIG_LINES: ${{ vars.MIN_WP_CONFIG_LINES }}
-      DRIFT_PERMISSIVE: ${{ secrets.DRIFT_PERMISSIVE }}
       # Resolve tarball inclusion for both manual & scheduled triggers
       SNAPSHOT_INCLUDE_TARBALL: ${{ github.event_name == 'workflow_dispatch' && inputs.include_tarball || 'true' }}
     steps:


### PR DESCRIPTION
## Summary
- avoid invalid job condition by referencing secrets via env
- centralize secrets mapping to workflow-level env

## Testing
- `npm test`
- `yamllint .github/workflows/remote-snapshot.yml`

------
https://chatgpt.com/codex/tasks/task_e_68bee92b8e0c832eaca8220a9335abd6