### PR TITLE
Simplify debug logging and tidy front page template

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -98,7 +98,7 @@ if ( ! defined( 'WP_DEBUG' ) ) {
     define( 'WP_DEBUG', true );
 }
 // Log debug messages to a file in wp-content for easier troubleshooting.
-define( 'WP_DEBUG_LOG', __DIR__ . '/wp-content/debug.log' );
+define( 'WP_DEBUG_LOG', true );
 define( 'WP_DEBUG_DISPLAY', false );
 
 /* That's all, stop editing! Happy publishing. */

--- a/wp-content/themes/kava/front-page.php
+++ b/wp-content/themes/kava/front-page.php
@@ -17,14 +17,14 @@ get_header();
         <p><?php bloginfo( 'description' ); ?></p>
         <?php get_search_form(); ?>
         <a class="cta-button" href="<?php echo esc_url( get_post_type_archive_link( 'post' ) ); ?>">
-            <?php _e( 'Browse All Posts', 'kava' ); ?>
+            <?php esc_html_e( 'Browse All Posts', 'kava' ); ?>
         </a>
     </div>
 </section>
 
 <section class="featured-properties">
     <div class="container">
-        <h2><?php _e( 'Featured Listings', 'kava' ); ?></h2>
+        <h2><?php esc_html_e( 'Featured Listings', 'kava' ); ?></h2>
         <?php
         $featured = new WP_Query( array(
             'post_type'      => 'post',
@@ -46,7 +46,7 @@ get_header();
             echo '</div>';
             wp_reset_postdata();
         else :
-            _e( 'No listings found.', 'kava' );
+            esc_html_e( 'No listings found.', 'kava' );
         endif;
         ?>
     </div>
@@ -54,4 +54,4 @@ get_header();
 
 <?php
 get_footer();
-?>
+


### PR DESCRIPTION
## Summary
- simplify debug logging by enabling WP's default log file
- tidy front page template with escaped translations and no trailing PHP tag

## Testing
- `npm test`
- `php -l wp-config.php`


------
https://chatgpt.com/codex/tasks/task_e_68beef77989c832e9f48c295e26851af