### PR TITLE
Use secrets context for remote snapshot workflow

### DIFF
--- a/.github/workflows/remote-snapshot.yml
+++ b/.github/workflows/remote-snapshot.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   snapshot:
     # Skip job entirely if required secrets are missing
-    if: ${{ env.HOSTINGER_SSH_HOST != '' && env.HOSTINGER_SSH_USER != '' && env.HOSTINGER_SSH_PORT != '' && env.HOSTINGER_PATH != '' && env.HOSTINGER_SSH_KEY != '' }}
+    if: ${{ secrets.HOSTINGER_SSH_HOST != '' && secrets.HOSTINGER_SSH_USER != '' && secrets.HOSTINGER_SSH_PORT != '' && secrets.HOSTINGER_PATH != '' && secrets.HOSTINGER_SSH_KEY != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## Summary
- use `secrets` context to gate `snapshot` job in remote-snapshot workflow

## Testing
- `yamllint .github/workflows/remote-snapshot.yml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68befccd24c4832ebdbc83f1f038c977