### PR TITLE
fix: avoid secrets context in workflow condition

### DIFF
--- a/.github/workflows/remote-snapshot.yml
+++ b/.github/workflows/remote-snapshot.yml
@@ -29,7 +29,10 @@ env:
 jobs:
   snapshot:
     # Skip job entirely if required secrets are missing
-    if: ${{ secrets.HOSTINGER_SSH_HOST != '' && secrets.HOSTINGER_SSH_USER != '' && secrets.HOSTINGER_SSH_PORT != '' && secrets.HOSTINGER_PATH != '' && secrets.HOSTINGER_SSH_KEY != '' }}
+    # GitHub expressions at the job level do not expose the `secrets` context.
+    # Populate env vars above from secrets and reference them here instead so
+    # the job is skipped gracefully when any required secret is unset.
+    if: ${{ env.HOSTINGER_SSH_HOST != '' && env.HOSTINGER_SSH_USER != '' && env.HOSTINGER_SSH_PORT != '' && env.HOSTINGER_PATH != '' && env.HOSTINGER_SSH_KEY != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## Summary
- use env references instead of `secrets` in job-level condition
- document reason for using env values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf00ff14d0832eb527f4c4373804d0