### PR TITLE
fix: verify required secrets before snapshot

### DIFF
--- a/.github/workflows/remote-snapshot.yml
+++ b/.github/workflows/remote-snapshot.yml
@@ -28,27 +28,34 @@ env:
 
 jobs:
   snapshot:
-    # Skip job entirely if required secrets are missing
-    # GitHub expressions at the job level do not expose the `secrets` context.
-    # Populate env vars above from secrets and reference them here instead so
-    # the job is skipped gracefully when any required secret is unset.
-    if: ${{ env.HOSTINGER_SSH_HOST != '' && env.HOSTINGER_SSH_USER != '' && env.HOSTINGER_SSH_PORT != '' && env.HOSTINGER_PATH != '' && env.HOSTINGER_SSH_KEY != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       # Resolve tarball inclusion for both manual & scheduled triggers
       SNAPSHOT_INCLUDE_TARBALL: ${{ github.event_name == 'workflow_dispatch' && inputs.include_tarball || 'true' }}
     steps:
+      - name: Check required secrets
+        id: check
+        run: |
+          if [[ -n "$HOSTINGER_SSH_HOST" && -n "$HOSTINGER_SSH_USER" && -n "$HOSTINGER_SSH_PORT" && -n "$HOSTINGER_PATH" && -n "$HOSTINGER_SSH_KEY" ]]; then
+            echo "secrets_present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "One or more required secrets are missing; skipping snapshot."
+            echo "secrets_present=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Checkout
+        if: steps.check.outputs.secrets_present == 'true'
         uses: actions/checkout@v4
 
       - name: Setup SSH key
+        if: steps.check.outputs.secrets_present == 'true'
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.HOSTINGER_SSH_KEY }}
           log-public-key: false
 
       - name: Run remote snapshot
+        if: steps.check.outputs.secrets_present == 'true'
         env:
           SNAPSHOT_TARBALL: ${{ env.SNAPSHOT_INCLUDE_TARBALL == 'true' && '1' || '0' }}
         run: |
@@ -56,6 +63,7 @@ jobs:
           scripts/remote_snapshot.sh
 
       - name: Drift / residue guard
+        if: steps.check.outputs.secrets_present == 'true'
         run: |
           set -euo pipefail
           dir=$(ls -1d snapshot_* | tail -n1)
@@ -82,6 +90,7 @@ jobs:
             echo "One or more drift conditions met (failing job)."; exit 1; else echo "No critical drift (or permissive mode)."; fi
 
       - name: Upload snapshot artifacts
+        if: steps.check.outputs.secrets_present == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: remote-snapshot


### PR DESCRIPTION
## Summary
- avoid invalid `env` reference by removing job-level condition
- add secret validation step and guard subsequent steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf02108538832ea191fd3171d34498