### PR TITLE
Sanitize front-page translations and valuation link

### DIFF
--- a/wp-content/themes/kava/front-page.php
+++ b/wp-content/themes/kava/front-page.php
@@ -12,7 +12,7 @@ get_header();
 
 <section class="aktonz-hero">
     <div class="container">
-        <h1><?php _e( "London's Estate Agent", 'kava' ); ?></h1>
+        <h1><?php esc_html_e( "London's Estate Agent", 'kava' ); ?></h1>
         <?php get_search_form(); ?>
     </div>
 </section>
@@ -22,19 +22,19 @@ get_header();
         <ul class="stats-grid">
             <li class="stat">
                 <span class="stat-number">96%</span>
-                <span class="stat-label"><?php _e( 'Customer satisfaction', 'kava' ); ?></span>
+                <span class="stat-label"><?php esc_html_e( 'Customer satisfaction', 'kava' ); ?></span>
             </li>
             <li class="stat">
                 <span class="stat-number">20k+</span>
-                <span class="stat-label"><?php _e( 'Properties managed', 'kava' ); ?></span>
+                <span class="stat-label"><?php esc_html_e( 'Properties managed', 'kava' ); ?></span>
             </li>
             <li class="stat">
                 <span class="stat-number">332</span>
-                <span class="stat-label"><?php _e( 'London specialists', 'kava' ); ?></span>
+                <span class="stat-label"><?php esc_html_e( 'London specialists', 'kava' ); ?></span>
             </li>
             <li class="stat">
                 <span class="stat-number">24/7</span>
-                <span class="stat-label"><?php _e( 'Online tracking', 'kava' ); ?></span>
+                <span class="stat-label"><?php esc_html_e( 'Online tracking', 'kava' ); ?></span>
             </li>
         </ul>
     </div>
@@ -42,24 +42,24 @@ get_header();
 
 <section class="aktonz-selling">
     <div class="container">
-        <h2><?php _e( 'Looking to sell or let your property?', 'kava' ); ?></h2>
-        <p><?php _e( 'Book a free valuation to find out what your property is worth.', 'kava' ); ?></p>
-        <a class="cta-button" href="/valuation"><?php _e( 'Book valuation', 'kava' ); ?></a>
+        <h2><?php esc_html_e( 'Looking to sell or let your property?', 'kava' ); ?></h2>
+        <p><?php esc_html_e( 'Book a free valuation to find out what your property is worth.', 'kava' ); ?></p>
+        <a class="cta-button" href="<?php echo esc_url( home_url( '/valuation' ) ); ?>"><?php esc_html_e( 'Book valuation', 'kava' ); ?></a>
     </div>
 </section>
 
 <section class="aktonz-search">
     <div class="container">
-        <h2><?php _e( 'Find a property that\'s right for you', 'kava' ); ?></h2>
+        <h2><?php esc_html_e( 'Find a property that\'s right for you', 'kava' ); ?></h2>
         <?php get_search_form(); ?>
     </div>
 </section>
 
 <section class="aktonz-testimonials">
     <div class="container">
-        <h2><?php _e( 'Testimonials', 'kava' ); ?></h2>
+        <h2><?php esc_html_e( 'Testimonials', 'kava' ); ?></h2>
         <blockquote>
-            <p><?php _e( 'Aktonz were brilliant helping me find my new home.', 'kava' ); ?></p>
+            <p><?php esc_html_e( 'Aktonz were brilliant helping me find my new home.', 'kava' ); ?></p>
             <cite>Greg Nelson</cite>
         </blockquote>
     </div>


### PR DESCRIPTION
## Summary
- escape translated strings on the front page
- sanitize valuation CTA link with `esc_url( home_url() )`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf0ec3639c832eb173922ebd0eb10c