### PR TITLE
Define layout property for Kava theme to avoid dynamic property deprecation

### DIFF
--- a/wp-content/themes/kava/functions.php
+++ b/wp-content/themes/kava/functions.php
@@ -72,6 +72,14 @@ if ( ! class_exists( 'Kava_Theme_Setup' ) ) {
 		public $dynamic_css = null;
 
 		/**
+		 * Layout configuration storage.
+		 *
+		 * @since 1.0.0
+		 * @var array
+		 */
+		public $layout = array();
+
+		/**
 		 * Sets up needed actions/filters for the theme to initialize.
 		 *
 		 * @since 1.0.0


### PR DESCRIPTION
## Summary
- declare `$layout` property on `Kava_Theme_Setup` to prevent PHP 8.2 dynamic property deprecation notices

## Testing
- `php -l wp-content/themes/kava/functions.php`
- `php -l wp-content/themes/kava/config/layout.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf28681ae0832e9a34349121171282