### PR TITLE
Adjust property header spacing on property details page

### DIFF
--- a/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
+++ b/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
@@ -150,7 +150,7 @@ $property_images = $details->images ?? [];
 </style>
 <div class="container-fluid px-0">
     <div class="container">
-        <div class="row g-4 mt-4">
+        <div class="row g-4 mt-4" style="--bs-gutter-x:30px;">
             <div class="col-lg-7">
 
 


### PR DESCRIPTION
## Summary
- increase horizontal gutter to 30px on property details layout so header sits beside image with consistent gap

## Testing
- `php -l wp-content/plugins/apex27-wp-plugin/templates/property-details.php`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf66dfd910832e92a2cff4ede31804