### PR TITLE
Define form path in property details template

### DIFF
--- a/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
+++ b/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
@@ -9,6 +9,7 @@ $options = $apex27->get_portal_options();
 $details = $apex27->get_property_details();
 $apex27->set_listing_details($details);
 $featured = !empty($details->isFeatured);
+$form_path = $apex27->get_template_path("enquiry-form");
 get_header();
 if(!$details) {
     ?>


### PR DESCRIPTION
## Summary
- Initialize `form_path` before rendering property details to avoid undefined variable warnings.

## Testing
- `php -l wp-content/plugins/apex27-wp-plugin/templates/property-details.php`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf671ba160832eb1b26decdc051c1a