### PR TITLE
Use slide-out offer form on property pages

### DIFF
--- a/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
+++ b/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
@@ -177,7 +177,7 @@ $property_images = $details->images ?? [];
                 <button class="btn btn-lg btn-warning mb-2" onclick="showViewingForm(); return false;">
                     <i class="fa fa-calendar-check"></i> Book Viewing
                 </button>
-                <button class="btn btn-lg btn-primary mb-2" onclick="showOfferForm(); return false;">
+                <button class="btn btn-lg btn-primary mb-2" type="button" onclick="showOfferForm();">
                     <i class="fa fa-hand-holding-usd"></i> Make Offer
                 </button>
                 <button class="btn btn-lg btn-outline-secondary mb-2" onclick="showEnquiryForm(); return false;">
@@ -324,7 +324,7 @@ $property_images = $details->images ?? [];
                         <button class="btn btn-lg btn-warning mb-2" onclick="showViewingForm(); return false;">
                             <i class="fa fa-calendar-check"></i> Book Viewing
                         </button>
-                        <button class="btn btn-lg btn-primary mb-2" onclick="showOfferForm(); return false;">
+                        <button class="btn btn-lg btn-primary mb-2" type="button" onclick="showOfferForm();">
                             <i class="fa fa-hand-holding-usd"></i> Make Offer
                         </button>
                     </div>
@@ -372,13 +372,6 @@ $property_images = $details->images ?? [];
         </form>
     </div>
 </div>
-<!-- Modal for Make Offer -->
-<div id="offer-form-modal" class="modal" style="display: none;">
-    <div class="modal-content">
-        <span class="close" onclick="closeOfferForm();">&times;</span>
-        <?php echo do_shortcode('[offrz_offer_form]'); ?>
-    </div>
-</div>
 <!-- Modal for Enquiry -->
 <div id="enquiry-form-modal" class="modal" style="display: none;">
     <div class="modal-content">
@@ -399,13 +392,6 @@ function showViewingForm() {
 }
 function closeViewingForm() {
     document.getElementById('viewing-form-modal').style.display = 'none';
-}
-function showOfferForm() {
-    document.getElementById('offer-form-modal').style.display = 'block';
-}
-function closeOfferForm() {
-    document.getElementById('offer-form-modal').style.display = 'none';
-
 }
 (function() {
     var slotCount = 1;

--- a/wp-content/plugins/offer-form/offer-form.css
+++ b/wp-content/plugins/offer-form/offer-form.css
@@ -14,16 +14,6 @@
 .offer-form-panel.active {
     transform: translateX(0);
 }
-.offer-form-open {
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    z-index: 999;
-    background: #ffce00;
-    border: none;
-    padding: 12px 20px;
-    cursor: pointer;
-}
 .offer-form-close {
     background: none;
     border: none;

--- a/wp-content/plugins/offer-form/offer-form.js
+++ b/wp-content/plugins/offer-form/offer-form.js
@@ -1,16 +1,29 @@
 document.addEventListener('DOMContentLoaded', function () {
+    var panel = document.getElementById('offer-form-panel');
     var openBtn = document.getElementById('offer-form-open');
     var closeBtn = document.getElementById('offer-form-close');
-    var panel = document.getElementById('offer-form-panel');
     var form = panel ? panel.querySelector('form') : null;
 
-    if (openBtn && closeBtn && panel) {
-        openBtn.addEventListener('click', function () {
+    function openPanel() {
+        if (panel) {
             panel.classList.add('active');
-        });
-        closeBtn.addEventListener('click', function () {
+        }
+    }
+
+    function closePanel() {
+        if (panel) {
             panel.classList.remove('active');
-        });
+        }
+    }
+
+    window.showOfferForm = openPanel;
+    window.closeOfferForm = closePanel;
+
+    if (openBtn) {
+        openBtn.addEventListener('click', openPanel);
+    }
+    if (closeBtn) {
+        closeBtn.addEventListener('click', closePanel);
     }
     if (form) {
         form.addEventListener('submit', function (e) {
@@ -27,7 +40,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (data.success) {
                     alert('Thank you for your offer!');
                     form.reset();
-                    panel.classList.remove('active');
+                    closePanel();
                 } else {
                     alert(data.data && data.data.message ? data.data.message : 'Error submitting offer');
                 }
@@ -37,5 +50,4 @@ document.addEventListener('DOMContentLoaded', function () {
             });
         });
     }
-
 });

--- a/wp-content/plugins/offer-form/offer-form.php
+++ b/wp-content/plugins/offer-form/offer-form.php
@@ -103,7 +103,6 @@ function offer_form_render_markup() {
             </form>
         </div>
     </div>
-    <button id="offer-form-open" class="offer-form-open" type="button"><?php esc_html_e('Make an offer', 'offer-form'); ?></button>
     <?php
 }
 add_action('wp_footer', 'offer_form_render_markup');


### PR DESCRIPTION
## Summary
- Replace outdated modal shortcode with slide-out offer panel
- Expose global functions to open/close offer panel
- Wire property page button to trigger the new panel

## Testing
- `php -l wp-content/plugins/offer-form/offer-form.php`
- `php -l wp-content/plugins/apex27-wp-plugin/templates/property-details.php`
- `node --check wp-content/plugins/offer-form/offer-form.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf6d028158832e84efb4612bbb2edd