### PR TITLE
Separate property header from sticky sidebar

### DIFF
--- a/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
+++ b/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
@@ -145,14 +145,35 @@ $property_images = $details->images ?? [];
 }
 .media-tab-content { display: none; }
 .media-tab-content.active { display: block; }
+
+.property-main {
+    display: flex;
+    gap: 30px;
+}
+.property-media-container {
+    flex: 0 0 600px;
+    max-width: 600px;
+}
+.property-sidebar {
+    flex: 0 0 350px;
+    max-width: 350px;
+}
 @media (max-width: 991px) {
+    .property-main {
+        flex-direction: column;
+    }
+    .property-media-container,
+    .property-sidebar {
+        flex: 1 1 100%;
+        max-width: 100%;
+    }
     .sticky-sidebar { position: static; top: auto; }
 }
 </style>
 <div class="container-fluid px-0">
     <div class="container">
-        <div class="row g-4 mt-4" style="--bs-gutter-x:30px;">
-            <div class="col-lg-7">
+        <div class="property-main mt-4">
+            <div class="property-media-container">
 
 
                 <div class="property-media-tabs mb-4">
@@ -261,42 +282,42 @@ $property_images = $details->images ?? [];
                     <?php }
                 } ?>
             </div>
-            <div class="col-lg-5">
-                <div class="sticky-sidebar">
-                    <div class="property-header mb-4">
-                        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
-                            <div>
-                                <h1 class="property-title mb-1"><?=htmlspecialchars($details->displayAddress)?></h1>
-                                <?php if (!empty($details->propertyType)) : ?>
-                                    <div class="text-muted mb-2" style="font-size:1.1rem;">
-                                        <?=htmlspecialchars($details->propertyType)?></div>
-                                <?php endif; ?>
-                                <?php if($featured): ?>
-                                    <span class="badge bg-success">Featured</span>
-                                <?php endif; ?>
-                            </div>
-                            <div class="property-meta d-flex flex-wrap gap-3 mt-2">
-                                <span><i class="fa fa-bed"></i> <?=htmlspecialchars($details->bedrooms)?> Beds</span>
-                                <span><i class="fa fa-bath"></i> <?=htmlspecialchars($details->bathrooms)?> Baths</span>
-                                <span><i class="fa fa-couch"></i> <?=htmlspecialchars($details->livingRooms)?> Living</span>
-                            </div>
+            <div class="property-sidebar">
+                <div class="property-header mb-4">
+                    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
+                        <div>
+                            <h1 class="property-title mb-1"><?=htmlspecialchars($details->displayAddress)?></h1>
+                            <?php if (!empty($details->propertyType)) : ?>
+                                <div class="text-muted mb-2" style="font-size:1.1rem;">
+                                    <?=htmlspecialchars($details->propertyType)?></div>
+                            <?php endif; ?>
+                            <?php if($featured): ?>
+                                <span class="badge bg-success">Featured</span>
+                            <?php endif; ?>
                         </div>
-                        <div class="property-price display-4 text-brand mt-3">
-                            <?=htmlspecialchars($details->displayPrice)?>
-                            <small><?=htmlspecialchars($details->pricePrefix)?></small>
-                        </div>
-                        <div class="property-actions mt-4 d-flex flex-wrap gap-2" style="gap:10px;">
-                            <a href="#property-details-contact-form" class="btn btn-lg btn-brand me-2 mb-2">
-                                <i class="fa fa-envelope"></i> Make Enquiry
-                            </a>
-                            <button class="btn btn-lg btn-warning mb-2" onclick="showViewingForm(); return false;">
-                                <i class="fa fa-calendar-check"></i> Book Viewing
-                            </button>
-                            <button class="btn btn-lg btn-primary mb-2" onclick="showOfferForm(); return false;">
-                                <i class="fa fa-hand-holding-usd"></i> Make Offer
-                            </button>
+                        <div class="property-meta d-flex flex-wrap gap-3 mt-2">
+                            <span><i class="fa fa-bed"></i> <?=htmlspecialchars($details->bedrooms)?> Beds</span>
+                            <span><i class="fa fa-bath"></i> <?=htmlspecialchars($details->bathrooms)?> Baths</span>
+                            <span><i class="fa fa-couch"></i> <?=htmlspecialchars($details->livingRooms)?> Living</span>
                         </div>
                     </div>
+                    <div class="property-price display-4 text-brand mt-3">
+                        <?=htmlspecialchars($details->displayPrice)?>
+                        <small><?=htmlspecialchars($details->pricePrefix)?></small>
+                    </div>
+                    <div class="property-actions mt-4 d-flex flex-wrap gap-2" style="gap:10px;">
+                        <a href="#property-details-contact-form" class="btn btn-lg btn-brand me-2 mb-2">
+                            <i class="fa fa-envelope"></i> Make Enquiry
+                        </a>
+                        <button class="btn btn-lg btn-warning mb-2" onclick="showViewingForm(); return false;">
+                            <i class="fa fa-calendar-check"></i> Book Viewing
+                        </button>
+                        <button class="btn btn-lg btn-primary mb-2" onclick="showOfferForm(); return false;">
+                            <i class="fa fa-hand-holding-usd"></i> Make Offer
+                        </button>
+                    </div>
+                </div>
+                <div class="sticky-sidebar">
                     <div class="mb-4">
                         <?php $apex27->include_template($form_path, ["property_details" => $details]); ?>
                     </div>


### PR DESCRIPTION
## Summary
- Separate the property header from the sticky sidebar so it can sit alongside property media
- Set fixed widths so the property header is ~350px and property media ~600px for consistent layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf6adcb4d0832e99fc56400f519d5f