### PR TITLE
Remove duplicate property header in property details template

### DIFF
--- a/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
+++ b/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
@@ -318,41 +318,6 @@ $property_images = $details->images ?? [];
             </div>
 
             <div class="col-lg-5">
-                <div class="property-header mb-4">
-                    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
-                        <div>
-                            <h1 class="property-title mb-1"><?=htmlspecialchars($details->displayAddress)?></h1>
-                            <?php if (!empty($details->propertyType)) : ?>
-                                <div class="text-muted mb-2" style="font-size:1.1rem;">
-                                    <?=htmlspecialchars($details->propertyType)?></div>
-                            <?php endif; ?>
-                            <?php if($featured): ?>
-                                <span class="badge bg-success">Featured</span>
-                            <?php endif; ?>
-                        </div>
-                        <div class="property-meta d-flex flex-wrap gap-3 mt-2">
-                            <span><i class="fa fa-bed"></i> <?=htmlspecialchars($details->bedrooms)?> Beds</span>
-                            <span><i class="fa fa-bath"></i> <?=htmlspecialchars($details->bathrooms)?> Baths</span>
-                            <span><i class="fa fa-couch"></i> <?=htmlspecialchars($details->livingRooms)?> Living</span>
-                        </div>
-                    </div>
-                    <div class="property-price display-4 text-brand mt-3">
-                        <?=htmlspecialchars($details->displayPrice)?>
-                        <small><?=htmlspecialchars($details->pricePrefix)?></small>
-                    </div>
-                    <div class="property-actions mt-4 d-flex flex-wrap gap-2" style="gap:10px;">
-                        <a href="#property-details-contact-form" class="btn btn-lg btn-brand me-2 mb-2">
-                            <i class="fa fa-envelope"></i> Make Enquiry
-                        </a>
-                        <button class="btn btn-lg btn-warning mb-2" onclick="showViewingForm(); return false;">
-                            <i class="fa fa-calendar-check"></i> Book Viewing
-                        </button>
-
-                        <button class="btn btn-lg btn-primary mb-2" type="button" onclick="showOfferForm();">
-                            <i class="fa fa-hand-holding-usd"></i> Make Offer
-                        </button>
-                    </div>
-                </div>
                 <div class="sticky-sidebar">
                     <div class="mb-4">
                         <?php $apex27->include_template($form_path, ["property_details" => $details]); ?>


### PR DESCRIPTION
## Summary
- remove duplicate property header from property details template so only one header is rendered

## Testing
- `npm test`
- `php -l wp-content/plugins/apex27-wp-plugin/templates/property-details.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf70e4a9d4832e81811773bd09f23d