### PR TITLE
Guard offer form button when script missing

### DIFF
--- a/wp-content/plugins/apex27-wp-plugin/templates/property-details-backup.php
+++ b/wp-content/plugins/apex27-wp-plugin/templates/property-details-backup.php
@@ -594,7 +594,7 @@ $show_back = strpos($referer, "search") !== false;
 
 				</a>
 
-				<a href="#" class="btn btn-brand" onclick="showOfferForm(); return false;">
+				<a href="#" class="btn btn-brand" onclick="if (typeof showOfferForm === 'function') { showOfferForm(); } return false;">
    				<?=htmlspecialchars(__("Make Offer", $text_domain))?>
 				</a>
 

--- a/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
+++ b/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
@@ -199,7 +199,7 @@ $property_images = $details->images ?? [];
                 <button class="btn btn-lg btn-warning mb-2" onclick="showViewingForm(); return false;">
                     <i class="fa fa-calendar-check"></i> Book Viewing
                 </button>
-                <button class="btn btn-lg btn-primary mb-2" type="button" onclick="showOfferForm();">
+                <button class="btn btn-lg btn-primary mb-2" type="button" onclick="if (typeof showOfferForm === 'function') { showOfferForm(); }">
                     <i class="fa fa-hand-holding-usd"></i> Make Offer
                 </button>
                 <button class="btn btn-lg btn-outline-secondary mb-2" onclick="showEnquiryForm(); return false;">
@@ -348,7 +348,7 @@ $property_images = $details->images ?? [];
                             <i class="fa fa-calendar-check"></i> Book Viewing
                         </button>
 
-                        <button class="btn btn-lg btn-primary mb-2" type="button" onclick="showOfferForm();">
+                        <button class="btn btn-lg btn-primary mb-2" type="button" onclick="if (typeof showOfferForm === 'function') { showOfferForm(); }">
                             <i class="fa fa-hand-holding-usd"></i> Make Offer
                         </button>
                     </div>


### PR DESCRIPTION
## Summary
- prevent ReferenceError when offer-form plugin inactive by only calling `showOfferForm` if defined

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf714087a8832e808f44c4441e0e2c