### PR TITLE
Add offer form trigger to property details page

### DIFF
--- a/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
+++ b/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
@@ -200,7 +200,7 @@ $property_images = $details->images ?? [];
                 <button class="btn btn-lg btn-warning mb-2" onclick="showViewingForm(); return false;">
                     <i class="fa fa-calendar-check"></i> Book Viewing
                 </button>
-                <button class="btn btn-lg btn-primary mb-2" type="button" onclick="showOfferForm();">
+                <button id="offer-form-open" class="btn btn-lg btn-primary mb-2" type="button">
                     <i class="fa fa-hand-holding-usd"></i> Make Offer
                 </button>
                 <button class="btn btn-lg btn-outline-secondary mb-2" onclick="showEnquiryForm(); return false;">


### PR DESCRIPTION
## Summary
- Wire up property detail "Make Offer" button to offer form slide-out panel.

## Testing
- `php -l wp-content/plugins/apex27-wp-plugin/templates/property-details.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf727006fc832e933b181b618426af