### PR TITLE
Move property header to sidebar with adjusted column widths

### DIFF
--- a/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
+++ b/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
@@ -158,6 +158,17 @@ $property_images = $details->images ?? [];
     flex: 0 0 350px;
     max-width: 350px;
 }
+
+@media (min-width: 992px) {
+    .left-column {
+        flex: 0 0 60%;
+        max-width: 60%;
+    }
+    .right-column {
+        flex: 0 0 30%;
+        max-width: 30%;
+    }
+}
 @media (max-width: 991px) {
     .property-main {
         flex-direction: column;
@@ -173,40 +184,8 @@ $property_images = $details->images ?? [];
 <div class="container-fluid px-0">
     <div class="container">
 
-        <div class="property-header mt-4">
-            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
-                <div>
-                    <h1 class="property-title mb-1"><?=htmlspecialchars($details->displayAddress)?></h1>
-                    <?php if (!empty($details->propertyType)) : ?>
-                        <div class="text-muted mb-2" style="font-size:1.1rem;">
-                            <?=htmlspecialchars($details->propertyType)?></div>
-                    <?php endif; ?>
-                    <?php if($featured): ?>
-                        <span class="badge bg-success">Featured</span>
-                    <?php endif; ?>
-                </div>
-                <div class="property-meta d-flex flex-wrap gap-3 mt-2">
-                    <span><i class="fa fa-bed"></i> <?=htmlspecialchars($details->bedrooms)?> Beds</span>
-                    <span><i class="fa fa-bath"></i> <?=htmlspecialchars($details->bathrooms)?> Baths</span>
-                    <span><i class="fa fa-couch"></i> <?=htmlspecialchars($details->livingRooms)?> Living</span>
-                </div>
-            </div>
-            <div class="property-price display-4 text-brand mt-3">
-                <?=htmlspecialchars($details->displayPrice)?>
-                <small><?=htmlspecialchars($details->pricePrefix)?></small>
-            </div>
-            <div class="property-actions mt-4 d-flex flex-wrap gap-2" style="gap:10px;">
-                <button class="btn btn-lg btn-warning mb-2" onclick="showViewingForm(); return false;">
-                    <i class="fa fa-calendar-check"></i> Book Viewing
-                </button>
-
-                <button class="btn btn-lg btn-primary mb-2" type="button" onclick="if (typeof showOfferForm === 'function') { showOfferForm(); }">
-                    <i class="fa fa-hand-holding-usd"></i> Make Offer
-                </button>
-            </div>
-        </div>
         <div class="row g-4">
-            <div class="col-12">
+            <div class="col-12 col-lg-8 left-column">
 
                 <div class="property-media-tabs mb-4">
                     <div class="media-tabs-nav">
@@ -315,8 +294,8 @@ $property_images = $details->images ?? [];
                 } ?>
             </div>
 
-            <div class="col-lg-5">
-                <div class="property-header mb-4">
+            <div class="col-12 col-lg-4 right-column">
+                <div class="property-header mt-4">
                     <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
                         <div>
                             <h1 class="property-title mb-1"><?=htmlspecialchars($details->displayAddress)?></h1>


### PR DESCRIPTION
## Summary
- Shift property header into a dedicated right sidebar with `mt-4`
- Define responsive left and right column widths (60% and 30%) for property details layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7cd41bbc832e8fbd032f25c8c272