### PR TITLE
Reduce property title font size on property details page

### DIFF
--- a/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
+++ b/wp-content/plugins/apex27-wp-plugin/templates/property-details.php
@@ -95,6 +95,9 @@ $property_images = $details->images ?? [];
 .property-actions .btn:last-child {
     margin-right: 0;
 }
+.property-title {
+    font-size: 1.25rem;
+}
 .property-meta span {
     font-size: 1.1rem;
     margin-right: 1.5rem;


### PR DESCRIPTION
## Summary
- shrink property title heading on property details template for better readability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf91ac2634832eba05beaa77fc70b5